### PR TITLE
semicolon delimited lists support for cloudformation

### DIFF
--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/StackBean.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/StackBean.java
@@ -118,11 +118,20 @@ public class StackBean extends AbstractDescribableImpl<StackBean> {
 		
 		Map<String, String> result = new HashMap<String, String>();
 		String token[] = null;
-		for (String param : parameters.split(",")) {
-			token = param.split("=");
-			result.put(token[0].trim(), env.expand(token[1].trim()));
-		}
 		
+		//semicolon delimited list
+		if(parameters.contains(";")) {
+			for (String param : parameters.split(";")) {
+				token = param.split("=");
+				result.put(token[0].trim(), env.expand(token[1].trim()));
+			}
+		} else {
+			//comma delimited parameter list
+			for (String param : parameters.split(",")) {
+				token = param.split("=");
+				result.put(token[0].trim(), env.expand(token[1].trim()));
+			}
+		}
 		return result;
 	}
 	

--- a/src/test/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/StackBeanTest.java
+++ b/src/test/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/StackBeanTest.java
@@ -66,5 +66,20 @@ public class StackBeanTest {
 		assertTrue(stackBean.getParsedParameters(env).values().size() == 4);
 		
 	}
+	
+	@Test
+	public void parsingParameters_With_Semicolons_Expand_Variables() throws Exception {
+		env.put("value1", "expandedValue1");
+		env.put("value2", "expandedValue2");
+		String parameters = "key1=$value1;key2=${value2}; key3=v1,v2,v3,v4; key4=${value4}";
+		stackBean = new StackBean("name", "description", "aRecipe", parameters, 0, "awsAccessKey", "awsSecretKey", true);
+		
+		assertTrue(stackBean.getParsedParameters(env).get("key1").equals("expandedValue1"));
+		assertTrue(stackBean.getParsedParameters(env).get("key2").equals("expandedValue2"));
+		assertTrue(stackBean.getParsedParameters(env).get("key3").equals("v1,v2,v3,v4"));
+		assertTrue(stackBean.getParsedParameters(env).get("key4").equals("${value4}"));
+		assertTrue(stackBean.getParsedParameters(env).values().size() == 4);
+		
+	}
 
 }


### PR DESCRIPTION
support for semicolon delimited lists to be able to to handle CommaDelimitedList value types (JENKINS-12828), still supports comma delimited lists too.  I created a test method parsingParameters_With_Semicolons_Expand_Variables that test that it supports both semicolons and comma delimited lists.
