### PR TITLE
Added ability to use S3 locations for cloudformation templates

### DIFF
--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
@@ -54,6 +54,7 @@ public class CloudFormation {
      */
     public static final long MIN_TIMEOUT = 300;
     private String stackName;
+    private Boolean isRecipeURL;
     private String recipe;
     private List<Parameter> parameters;
     private long timeout;
@@ -75,6 +76,7 @@ public class CloudFormation {
      * @param logger a logger to write progress information.
      * @param stackName the name of the stack as defined in the AWS
      * CloudFormation API.
+     * @param isRecipeURL true to treat the recipeBody as a URL
      * @param recipeBody the body of the json document describing the stack.
      * @param parameters a Map of where the keys are the param name and the
      * value the param value.
@@ -84,13 +86,14 @@ public class CloudFormation {
      * @param awsAccessKey the AWS API Access Key.
      * @param awsSecretKey the AWS API Secret Key.
      */
-    public CloudFormation(PrintStream logger, String stackName,
+    public CloudFormation(PrintStream logger, String stackName, Boolean isRecipeURL,
             String recipeBody, Map<String, String> parameters,
             long timeout, String awsAccessKey, String awsSecretKey, Region region,
             boolean autoDeleteStack, EnvVars envVars, Boolean isPrefixSelected) {
 
         this.logger = logger;
         this.stackName = stackName;
+        this.isRecipeURL = isRecipeURL;
         this.recipe = recipeBody;
         this.parameters = parameters(parameters);
         this.awsAccessKey = awsAccessKey;
@@ -110,13 +113,14 @@ public class CloudFormation {
         this.envVars = envVars;
     
     }
-    public CloudFormation(PrintStream logger, String stackName,
+    public CloudFormation(PrintStream logger, String stackName, Boolean isRecipeURL,
             String recipeBody, Map<String, String> parameters,
             long timeout, String awsAccessKey, String awsSecretKey, Region region,
             EnvVars envVars, Boolean isPrefixSelected,long sleep) {
 
         this.logger = logger;
         this.stackName = stackName;
+        this.isRecipeURL = isRecipeURL;
         this.recipe = recipeBody;
         this.parameters = parameters(parameters);
         this.awsAccessKey = awsAccessKey;
@@ -136,11 +140,11 @@ public class CloudFormation {
         this.sleep=sleep;
     
     }
-    public CloudFormation(PrintStream logger, String stackName,
+    public CloudFormation(PrintStream logger, String stackName, Boolean isRecipeURL,
             String recipeBody, Map<String, String> parameters, long timeout,
             String awsAccessKey, String awsSecretKey, boolean autoDeleteStack,
             EnvVars envVars, Boolean isPrefixSelected) {
-        this(logger, stackName, recipeBody, parameters, timeout, awsAccessKey,
+        this(logger, stackName, isRecipeURL, recipeBody, parameters, timeout, awsAccessKey,
                 awsSecretKey, null, autoDeleteStack, envVars, isPrefixSelected);
     }
 
@@ -361,7 +365,11 @@ public class CloudFormation {
         CreateStackRequest r = new CreateStackRequest();
         r.withStackName(getExpandedStackName());
         r.withParameters(parameters);
-        r.withTemplateBody(recipe);
+        if (isRecipeURL) {
+            r.withTemplateURL(recipe);
+        } else {
+            r.withTemplateBody(recipe);
+        }
         r.withCapabilities("CAPABILITY_IAM");
 
         return r;

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
@@ -453,4 +453,14 @@ public class CloudFormation {
         }
         return map;
     }
+
+    public static boolean isRecipeURL(String recipe) {
+        // if the recipe name begins with http:// or https:// then treat as a URL
+        // ...didn't want to catch files that start with http
+        if(recipe.regionMatches(true, 0, "http://", 0, 7)
+            || recipe.regionMatches(true, 0, "https://", 0, 8)) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationBuildStep.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationBuildStep.java
@@ -102,10 +102,7 @@ public class CloudFormationBuildStep extends Builder{
 
 		Boolean isURL = false;
 		String recipe = null;
-        // if the recipe name begins with http:// or https:// then treat as a URL
-        // ...didn't want to catch files that start with http
-		if(postBuildStackBean.getCloudFormationRecipe().regionMatches(true, 0, "http://", 0, 7)
-			|| postBuildStackBean.getCloudFormationRecipe().regionMatches(true, 0, "https://", 0, 8)) {
+		if(CloudFormation.isRecipeURL(postBuildStackBean.getCloudFormationRecipe())) {
 			isURL = true;
 			recipe = postBuildStackBean.getCloudFormationRecipe();
 		} else {

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationBuildStep.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationBuildStep.java
@@ -100,9 +100,20 @@ public class CloudFormationBuildStep extends Builder{
 			AbstractBuild<?, ?> build, EnvVars env, PrintStream logger)
 			throws IOException {
 
-		return new CloudFormation(logger, postBuildStackBean.getStackName(), build
-				.getWorkspace().child(postBuildStackBean.getCloudFormationRecipe())
-				.readToString(), postBuildStackBean.getParsedParameters(env),
+		Boolean isURL = false;
+		String recipe = null;
+        // if the recipe name begins with http:// or https:// then treat as a URL
+        // ...didn't want to catch files that start with http
+		if(postBuildStackBean.getCloudFormationRecipe().regionMatches(true, 0, "http://", 0, 7)
+			|| postBuildStackBean.getCloudFormationRecipe().regionMatches(true, 0, "https://", 0, 8)) {
+			isURL = true;
+			recipe = postBuildStackBean.getCloudFormationRecipe();
+		} else {
+			recipe = build.getWorkspace().child(postBuildStackBean.getCloudFormationRecipe()).readToString();
+		}
+
+		return new CloudFormation(logger, postBuildStackBean.getStackName(), isURL,
+				recipe, postBuildStackBean.getParsedParameters(env),
 				postBuildStackBean.getTimeout(), postBuildStackBean.getParsedAwsAccessKey(env),
 				postBuildStackBean.getParsedAwsSecretKey(env),
 				postBuildStackBean.getAwsRegion(), env,false,postBuildStackBean.getSleep());

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationBuildWrapper.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationBuildWrapper.java
@@ -121,9 +121,20 @@ public class CloudFormationBuildWrapper extends BuildWrapper {
 			AbstractBuild<?, ?> build, EnvVars env, PrintStream logger)
 			throws IOException {
 
-		return new CloudFormation(logger, stackBean.getStackName(), build
-				.getWorkspace().child(stackBean.getCloudFormationRecipe())
-				.readToString(), stackBean.getParsedParameters(env),
+		Boolean isURL = false;
+		String recipe = null;
+        // if the recipe name begins with http:// or https:// then treat as a URL
+        // ...didn't want to catch files that start with http
+		if(stackBean.getCloudFormationRecipe().regionMatches(true, 0, "http://", 0, 7)
+			|| stackBean.getCloudFormationRecipe().regionMatches(true, 0, "https://", 0, 8)) {
+			isURL = true;
+			recipe = stackBean.getCloudFormationRecipe();
+		} else {
+			recipe = build.getWorkspace().child(stackBean.getCloudFormationRecipe()).readToString();
+		}
+
+		return new CloudFormation(logger, stackBean.getStackName(), isURL,
+				recipe, stackBean.getParsedParameters(env),
 				stackBean.getTimeout(), stackBean.getParsedAwsAccessKey(env),
 				stackBean.getParsedAwsSecretKey(env),
 				stackBean.getAwsRegion(), stackBean.getAutoDeleteStack(), env,false);

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationBuildWrapper.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationBuildWrapper.java
@@ -123,10 +123,8 @@ public class CloudFormationBuildWrapper extends BuildWrapper {
 
 		Boolean isURL = false;
 		String recipe = null;
-        // if the recipe name begins with http:// or https:// then treat as a URL
-        // ...didn't want to catch files that start with http
-		if(stackBean.getCloudFormationRecipe().regionMatches(true, 0, "http://", 0, 7)
-			|| stackBean.getCloudFormationRecipe().regionMatches(true, 0, "https://", 0, 8)) {
+		
+		if(CloudFormation.isRecipeURL(stackBean.getCloudFormationRecipe())) {
 			isURL = true;
 			recipe = stackBean.getCloudFormationRecipe();
 		} else {

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationNotifier.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationNotifier.java
@@ -67,6 +67,7 @@ public class CloudFormationNotifier extends Notifier {
 			CloudFormation cloudFormation = new CloudFormation(
 					listener.getLogger(),
 					stack.getStackName(),
+					false,
 					"",
 					new HashMap<String, String>(),
 					0,

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationPostBuildNotifier.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationPostBuildNotifier.java
@@ -101,10 +101,7 @@ public class CloudFormationPostBuildNotifier extends Notifier{
 
 		Boolean isURL = false;
 		String recipe = null;
-        // if the recipe name begins with http:// or https:// then treat as a URL
-        // ...didn't want to catch files that start with http
-		if(postBuildStackBean.getCloudFormationRecipe().regionMatches(true, 0, "http://", 0, 7)
-			|| postBuildStackBean.getCloudFormationRecipe().regionMatches(true, 0, "https://", 0, 8)) {
+		if(CloudFormation.isRecipeURL(postBuildStackBean.getCloudFormationRecipe())) {
 			isURL = true;
 			recipe = postBuildStackBean.getCloudFormationRecipe();
 		} else {

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationPostBuildNotifier.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationPostBuildNotifier.java
@@ -99,9 +99,20 @@ public class CloudFormationPostBuildNotifier extends Notifier{
 			AbstractBuild<?, ?> build, EnvVars env, PrintStream logger)
 			throws IOException {
 
-		return new CloudFormation(logger, postBuildStackBean.getStackName(), build
-				.getWorkspace().child(postBuildStackBean.getCloudFormationRecipe())
-				.readToString(), postBuildStackBean.getParsedParameters(env),
+		Boolean isURL = false;
+		String recipe = null;
+        // if the recipe name begins with http:// or https:// then treat as a URL
+        // ...didn't want to catch files that start with http
+		if(postBuildStackBean.getCloudFormationRecipe().regionMatches(true, 0, "http://", 0, 7)
+			|| postBuildStackBean.getCloudFormationRecipe().regionMatches(true, 0, "https://", 0, 8)) {
+			isURL = true;
+			recipe = postBuildStackBean.getCloudFormationRecipe();
+		} else {
+			recipe = build.getWorkspace().child(postBuildStackBean.getCloudFormationRecipe()).readToString();
+		}
+
+		return new CloudFormation(logger, postBuildStackBean.getStackName(), isURL,
+				recipe, postBuildStackBean.getParsedParameters(env),
 				postBuildStackBean.getTimeout(), postBuildStackBean.getParsedAwsAccessKey(env),
 				postBuildStackBean.getParsedAwsSecretKey(env),
 				postBuildStackBean.getAwsRegion(), env,false,postBuildStackBean.getSleep());

--- a/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/PostBuildStackBean/config.jelly
+++ b/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/PostBuildStackBean/config.jelly
@@ -5,7 +5,7 @@
 		<f:entry field="awsRegion" title="AWS Region">
 			<f:select />
 		</f:entry>
-		<f:entry title="Cloud Formation recipe file. (.json)" field="cloudFormationRecipe">
+		<f:entry title="Cloud Formation recipe file/S3 URL. (.json)" field="cloudFormationRecipe">
 			<f:textbox />
 		</f:entry>
 		<f:entry title="Stack name" field="stackName">

--- a/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/PostBuildStackBean/help-CloudFormationRecipe.html
+++ b/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/PostBuildStackBean/help-CloudFormationRecipe.html
@@ -1,3 +1,3 @@
 <div>
-	The Cloud Formation Recipe file. It is a json document. The path is relative the workspace.
+	The Cloud Formation Recipe file or S3 URL. It is a json document. For file, path is relative the workspace.
 <div>

--- a/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/StackBean/config.jelly
+++ b/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/StackBean/config.jelly
@@ -5,7 +5,7 @@
 		<f:entry field="awsRegion" title="AWS Region">
 			<f:select />
 		</f:entry>
-		<f:entry title="Cloud Formation recipe file. (.json)" field="cloudFormationRecipe">
+		<f:entry title="Cloud Formation recipe file/S3 URL. (.json)" field="cloudFormationRecipe">
 			<f:textbox />
 		</f:entry>
 		<f:entry title="Stack name" field="stackName">

--- a/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/StackBean/help-CloudFormationRecipe.html
+++ b/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/StackBean/help-CloudFormationRecipe.html
@@ -1,3 +1,3 @@
 <div>
-	The Cloud Formation Recipe file. It is a json document. The path is relative the workspace.
+	The Cloud Formation Recipe file or S3 URL. It is a json document. For file, the path is relative the workspace.
 <div>

--- a/src/test/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationTest.java
+++ b/src/test/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationTest.java
@@ -45,7 +45,7 @@ public class CloudFormationTest {
 	@Before
 	public void setup() throws Exception {
 
-		cf = new CloudFormation(System.out, TEST_STACK, recipeBody, parameters,
+		cf = new CloudFormation(System.out, TEST_STACK, false, recipeBody, parameters,
 				-12345, awsAccessKey, awsSecretKey, true, new EnvVars(),false) {
 			@Override
 			protected AmazonCloudFormation getAWSClient() {


### PR DESCRIPTION
Updated the cloudformation plugin to handle a CloudFormation recipe
entry of a URL as an S3 location for AWS to use.  This allows for larger
cloudformation templates beyond the 51,200 bytes similar to the AWS
Console.