### PR TITLE
JENKINS-30819: Fix plugin to be able to update an existing stack

### DIFF
--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
@@ -186,7 +186,6 @@ public class CloudFormation {
     public boolean create() throws TimeoutException, InterruptedException {
 
         logger.println("Determining to create or update Cloud Formation stack: " + getExpandedStackName());
-        Stack stack = null;
 
         try {
             try {

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
@@ -376,7 +376,7 @@ public class CloudFormation {
     }
 
     private boolean isStackCreationSuccessful(StackStatus status) {
-        return status == StackStatus.CREATE_COMPLETE || status == StackStatus.UPDATE_COMPLETE;
+        return status == StackStatus.CREATE_COMPLETE || status == StackStatus.UPDATE_COMPLETE || status == StackStatus.UPDATE_COMPLETE_CLEANUP_IN_PROGRESS;
     }
 
     private long getWaitBetweenAttempts (int retries) {

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
@@ -186,11 +186,12 @@ public class CloudFormation {
     public boolean create() throws TimeoutException, InterruptedException {
 
         logger.println("Determining to create or update Cloud Formation stack: " + getExpandedStackName());
+        Stack stack = null;
 
         try {
             try {
                 DescribeStacksRequest describeStacksRequest = new DescribeStacksRequest().withStackName(getExpandedStackName());
-                Stack stack = getStack(amazonClient.describeStacks(describeStacksRequest));
+                stack = getStack(amazonClient.describeStacks(describeStacksRequest));
             } catch (AmazonServiceException e) {
                 logger.println("Stack not found: " + getExpandedStackName() + ". Reason: " + detailedError(e));
             } catch (AmazonClientException e) {


### PR DESCRIPTION
The 'stack' variable was initialized within the try block so when
it was used to determine if the stack existed or not the variable
was out of scope so it always returned 'null'.  I initialized the
variable outside the try block so when it is checked to be null
it will have a value if the stack exists.