### PR TITLE
fixes missing region for client used in getAllRunningStacks

### DIFF
--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationNotifier.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormationNotifier.java
@@ -76,7 +76,8 @@ public class CloudFormationNotifier extends Notifier {
 					stack.getAwsRegion(),
 					false,
 					envVars,
-                                stack.getIsPrefixSelected()
+                    stack.getIsPrefixSelected(),
+                    stack.getRetainStacksQty()
 			);
 			if(cloudFormation.delete()) {
 				LOGGER.info("Success");

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean.java
@@ -43,20 +43,23 @@ public class SimpleStackBean extends AbstractDescribableImpl<SimpleStackBean> {
 	 */
 	private Region awsRegion;
         
-        private Boolean isPrefixSelected;
-        
+	private Boolean isPrefixSelected;
+
+	/**
+	 * number of stack to retain on tear down
+	 */
+	private long retainStacksQty = 1;
        
  
 	@DataBoundConstructor
 	public SimpleStackBean(String stackName, String awsAccessKey,
-			String awsSecretKey, Region awsRegion,Boolean isPrefixSelected) {
+			String awsSecretKey, Region awsRegion,Boolean isPrefixSelected, long retainStacksQty) {
 		this.stackName = stackName;
 		this.awsAccessKey = awsAccessKey;
 		this.awsSecretKey = awsSecretKey;
 		this.awsRegion = awsRegion != null ? awsRegion : Region.getDefault();
-                this.isPrefixSelected=isPrefixSelected;
-                
-          
+		this.isPrefixSelected=isPrefixSelected;
+		this.retainStacksQty = retainStacksQty;
 	}
 
 	public String getStackName() {
@@ -70,9 +73,14 @@ public class SimpleStackBean extends AbstractDescribableImpl<SimpleStackBean> {
 	public String getAwsSecretKey() {
 		return awsSecretKey;
 	}
-       public Boolean getIsPrefixSelected() {
+
+    public Boolean getIsPrefixSelected() {
 		return isPrefixSelected;
 	}
+
+    public long getRetainStacksQty() {
+        return retainStacksQty;
+    }
 
 	public String getParsedAwsAccessKey(EnvVars env) {
 		return env.expand(getAwsAccessKey());
@@ -104,6 +112,19 @@ public class SimpleStackBean extends AbstractDescribableImpl<SimpleStackBean> {
 			}
 			return FormValidation.ok();
 		}
+
+        public FormValidation doCheckretainStacksQty(
+                @AncestorInPath AbstractProject<?, ?> project,
+                @QueryParameter String value) throws IOException {
+            if (value.length() > 0) {
+                try {
+                    Long.parseLong(value);
+                } catch (NumberFormatException e) {
+                    return FormValidation.error("Retain Stack Qty value "+ value + " is not a number.");
+                }
+            }
+            return FormValidation.ok();
+        }
 
 		public FormValidation doCheckAwsAccessKey(
 				@AncestorInPath AbstractProject<?, ?> project,

--- a/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean/config.jelly
+++ b/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean/config.jelly
@@ -12,6 +12,9 @@
         <f:entry title="prefix" field="isPrefixSelected">
             <f:checkbox/>
         </f:entry>
+        <f:entry title="Retain Qty" field="retainStacksQty">
+            <f:textbox />
+        </f:entry>
         <f:entry title="AWS Access Key" field="awsAccessKey">
             <f:textbox />
         </f:entry>

--- a/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean/help-retainStacksQty.html
+++ b/src/main/resources/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/SimpleStackBean/help-retainStacksQty.html
@@ -1,0 +1,1 @@
+<div>The minimum number of stacks to retain when tearing down.</div>


### PR DESCRIPTION
refactors getting oldest stack to ensure oldest stack is retrieved if not sequenced in date order
add ability to define number of stacks to retain when tearing down
improves output to indicate when prefixed stack cannot be torn down
