### PR TITLE
No error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,11 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<!--version>4.5.2</version-->
 			<version>4.3.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
-			<!--version>4.4.5</version-->
 			<version>4.3.2</version>
 		</dependency>
 		<dependency>
@@ -58,17 +56,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<!--dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk-core</artifactId>
-			<version>1.11.46</version>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency-->
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
@@ -101,17 +88,6 @@
 				<directory>src/test/resources</directory>
 			</testResource>
 		</testResources>
-                <!--plugins>
-    <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
-        <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
-        </configuration>
-    </plugin>
-</plugins-->
 		<pluginManagement>
 		  <plugins>
 		      <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<artifactId>jenkins-cloudformation-plugin</artifactId>
 	<version>1.3-SNAPSHOT</version>
-	
+
 	<url>https://wiki.jenkins-ci.org/display/JENKINS/AWS+Cloudformation+Plugin</url>
 
 	<licenses>
@@ -38,11 +38,13 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
+			<!--version>4.5.2</version-->
 			<version>4.3.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
+			<!--version>4.4.5</version-->
 			<version>4.3.2</version>
 		</dependency>
 		<dependency>
@@ -56,6 +58,17 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<!--dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-core</artifactId>
+			<version>1.11.46</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency-->
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
@@ -88,6 +101,17 @@
 				<directory>src/test/resources</directory>
 			</testResource>
 		</testResources>
+                <!--plugins>
+    <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+        </configuration>
+    </plugin>
+</plugins-->
 		<pluginManagement>
 		  <plugins>
 		      <plugin>
@@ -119,7 +143,7 @@
 		<url>https://github.com/jenkinsci/jenkins-cloudformation-plugin</url>
 	  <tag>HEAD</tag>
   </scm>
-	
+
 
     <repositories>
         <repository>
@@ -138,7 +162,7 @@
 	<properties>
 	   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
-  
-</project>  
-  
+
+</project>
+
 

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.http.conn.ssl.*;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
@@ -219,15 +218,7 @@ public class CloudFormation {
             int count = 0;
             int maxTries = 3;
             StackStatus status;
-            //while(true) {
-            //    try {
-                    status = getStackStatus(stack.getStackStatus());
-            //        break;
-            //    } catch (AmazonClientException e) {
-            //        logger.println("Got an error getting stack status, retrying "+count+" out of "+maxTries+" times");
-            //        if (++count == maxTries) throw e;
-            //    }
-            //}
+            status = getStackStatus(stack.getStackStatus());
 
             Map<String, String> stackOutput = new HashMap<String, String>();
             if (isStackCreationSuccessful(status)) {

--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.http.conn.ssl.*;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
@@ -104,7 +105,7 @@ public class CloudFormation {
         this.awsSecretKey = awsSecretKey;
         this.awsRegion = region != null ? region : Region.getDefault();
         this.isPrefixSelected = isPrefixSelected;
-        
+
         if (timeout == -12345) {
             this.timeout = 0; // Faster testing.
         } else {
@@ -113,7 +114,7 @@ public class CloudFormation {
         this.amazonClient = getAWSClient();
         this.autoDeleteStack = autoDeleteStack;
         this.envVars = envVars;
-    
+
     }
     public CloudFormation(PrintStream logger, String stackName, Boolean isRecipeURL,
             String recipeBody, Map<String, String> parameters,
@@ -138,7 +139,7 @@ public class CloudFormation {
         this.autoDeleteStack = false;
         this.envVars = envVars;
         this.sleep=sleep;
-    
+
     }
     public CloudFormation(PrintStream logger, String stackName, Boolean isRecipeURL,
             String recipeBody, Map<String, String> parameters, long timeout,
@@ -221,9 +222,9 @@ public class CloudFormation {
             Map<String, String> stackOutput = new HashMap<String, String>();
             if (isStackCreationSuccessful(status)) {
                 List<Output> outputs = stack.getOutputs();
-                for (Output output : outputs) {
-                    stackOutput.put(output.getOutputKey(), output.getOutputValue());
-                }
+                //for (Output output : outputs) {
+                //    stackOutput.put(output.getOutputKey(), output.getOutputValue());
+                //}
 
                 logger.println("Successfully created stack: " + getExpandedStackName());
                 this.outputs = stackOutput;
@@ -254,7 +255,7 @@ public class CloudFormation {
     protected AmazonCloudFormation getAWSClient() {
         AWSCredentials credentials = new BasicAWSCredentials(this.awsAccessKey,
                 this.awsSecretKey);
-        Hudson hudson = Hudson.getInstance(); 
+        Hudson hudson = Hudson.getInstance();
         ProxyConfiguration proxyConfig = hudson != null ? hudson.proxy : null;
         if (proxyConfig != null && proxyConfig.name != null) {
            ClientConfiguration config = new ClientConfiguration();
@@ -266,7 +267,7 @@ public class CloudFormation {
            AWSCredentialsProvider provider = new BasicAWSCredentialsProvider(credentials);
            AmazonCloudFormation amazonClient = new AmazonCloudFormationAsyncClient(
                    provider, config);
-   
+
            amazonClient.setEndpoint(awsRegion.endPoint);
            return amazonClient;
         } else {
@@ -300,7 +301,7 @@ public class CloudFormation {
               }
 
               logger.println("Stack status " + stackStatus + ".");
-              
+
             } catch (AmazonServiceException ase) {
                 if (!RetryUtils.isThrottlingException(ase)) {
                     throw ase;
@@ -454,7 +455,7 @@ public class CloudFormation {
 
         return r;
 	}
-	
+
     public Map<String, String> getOutputs() {
         // Prefix outputs with stack name to prevent collisions with other stacks created in the same build.
         HashMap<String, String> map = new HashMap<String, String>();
@@ -494,7 +495,7 @@ public class CloudFormation {
                 stackToDelete = summary.getStackName();
             }
         }
-        
+
         return stackToDelete;
     }
 
@@ -546,19 +547,19 @@ public class CloudFormation {
 }
 
 class BasicAWSCredentialsProvider implements AWSCredentialsProvider {
-   
+
    AWSCredentials awsCredentials;
-   
+
    public BasicAWSCredentialsProvider(AWSCredentials awsCredentials) {
        this.awsCredentials = awsCredentials;
    }
-   
+
    public AWSCredentials getCredentials() {
        return awsCredentials;
    }
-   
+
    public void refresh() {
-       
+
    }
-   
+
 }


### PR DESCRIPTION
We used to use this plugin and had no issues, then we switched to running it in a docker container and started getting errors like: `com.ctc.wstx.exc.WstxIOException` which when run in debug would point to a timeout from aws.  When I run the container locally I could not reproduce the problem. but when running on another host in our environment I could reproduce it.  This pull request adds a retry around the call that was failing.  Another fix would be to remove it, as it appears to not be necessary, but I went the route of least change.  We have started to use this version in our environment and the issue has gone away as a second retry works.

My .editorconfig removed a lot of unecessary whitespace