### PR TITLE
Remove Java 8 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 #!groovy
 
 buildPlugin(configurations: [
-              [platform: 'linux', jdk: '8'],
               [platform: 'linux', jdk: '11'],
               [platform: 'windows', jdk: '11']
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
 #!groovy
 
-buildPlugin(configurations: [
-              [platform: 'linux', jdk: '11'],
-              [platform: 'windows', jdk: '11']
+
+buildPlugin(
+    useContainerAgent: true,
+    configurations: [
+        [platform: 'linux', jdk: '11'],
+        [platform: 'windows', jdk: '11']
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     </build>
 
     <scm>
-        <connection>scm:git:git@github.com:${gitHubRepo}.git</connection>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
         <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
         <url>https://github.com/${gitHubRepo}</url>
         <tag>${scmTag}</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.332.x</artifactId>
-                <version>1678.vc1feb_6a_3c0f1</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1750.v0071fa_4c4a_e3</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.50</version>
+        <version>4.52</version>
     </parent>
 
     <packaging>hpi</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     </pluginRepositories>
 
     <properties>
-        <jenkins.version>2.332.4</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/jenkins-cloudformation-plugin</gitHubRepo>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Updated the plugin's dependencies according to https://www.jenkins.io/blog/2022/12/14/require-java-11/
