### PR TITLE
Adjust the back-off algorithm to be less aggressive when waiting for stack creation and deletion

### DIFF
--- a/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
+++ b/src/main/java/com/syncapse/jenkinsci/plugins/awscloudformationwrapper/CloudFormation.java
@@ -299,6 +299,7 @@ public class CloudFormation {
             }
             sleep(stack, throttled);
         }
+        logger.println("Stack status " + status + " in " + ((subTime - startTime) / 1000) + " seconds");
         return StackStatus.DELETE_COMPLETE == status;
     }
 
@@ -356,6 +357,7 @@ public class CloudFormation {
                 sleep(stack, throttled);
             }
         }
+        logger.println("Stack status " + status + " in " + ((subTime - startTime) / 1000) + " seconds");
 
         printStackEvents();
 


### PR DESCRIPTION
Hi, love your product but we found that our builds were taking up to 10 minutes longer than necessary.

We found out that it was due to the back-off algorithm allowing up to 5 minutes between checks to see if the creation or deletion was complete.

We had a bit of spare time so we improved the algorithm, could you possibly pull this in to your next release of the plugin?

We adjusted the back-off algorithm for checking the status of the stack to only slow down if Amazon actually throttles the request.

It now will default to checking once every 5 seconds with a doubling back-off every time Amazon returns with a request throttled response.

Added some extra logging which we thought was helpful.

### Testing done

The existing automated tests still pass, and have run the modified plugin on our Jenkins to see the new log outputs in action and that it takes less time now. (See attached screenshots).

![image](https://github.com/user-attachments/assets/b4ef9375-36d4-41e1-8d55-4d0e35af6331)

![image](https://github.com/user-attachments/assets/065cacb4-d452-492c-8abe-bc8b520d3eb9)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
